### PR TITLE
Update package references and simplify XAML templates

### DIFF
--- a/src/DPUnity.Wpf.DpDataGrid.csproj
+++ b/src/DPUnity.Wpf.DpDataGrid.csproj
@@ -1,21 +1,29 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
-    <Nullable>enable</Nullable>
-    <UseWPF>true</UseWPF>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Version>1.0.3</Version>
-    <PackageId>DPUnity.Wpf.DpDataGrid</PackageId>
-    <Title>DPUnity WPF DataGrid</Title>
-    <Description>Enhanced DataGrid controls for WPF applications</Description>
-    <Authors>vanlk</Authors>
-    <Company>DPUnity</Company>
-    <RepositoryUrl>https://github.com/namdpu/DPUnity.Wpf.DataGrid</RepositoryUrl>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0-windows</TargetFramework>
+		<Nullable>enable</Nullable>
+		<UseWPF>true</UseWPF>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Version>1.0.3</Version>
+		<PackageId>DPUnity.Wpf.DpDataGrid</PackageId>
+		<Title>DPUnity WPF DataGrid</Title>
+		<Description>Enhanced DataGrid controls for WPF applications</Description>
+		<Authors>vanlk</Authors>
+		<Company>DPUnity</Company>
+		<RepositoryUrl>https://github.com/namdpu/DPUnity.Wpf.DataGrid</RepositoryUrl>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="DPUnity.Wpf.UI" Version="1.0.8.2-preview-7" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.8.4" />
+		<PackageReference Include="HandyControls" Version="3.6.0" />
+	</ItemGroup>
+
+	<!--<ItemGroup>
+	  <Reference Include="DPUnity.Wpf.UI">
+	    <HintPath>..\..\DPUnity.Wpf.UI\bin\Debug\net8.0-windows\DPUnity.Wpf.UI.dll</HintPath>
+	  </Reference>
+	</ItemGroup>-->
+
 
 </Project>

--- a/src/Themes/Generic.xaml
+++ b/src/Themes/Generic.xaml
@@ -64,10 +64,9 @@
                 <ControlTemplate TargetType="{x:Type DataGridCell}">
                     <Border Background="{TemplateBinding Background}"
                             Padding="{TemplateBinding Padding}"
-                            SnapsToDevicePixels="True">
+                            >
                         <ContentPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>
@@ -168,7 +167,6 @@
                                         <Setter.Value>
                                             <ControlTemplate TargetType="Button">
                                                 <Border Background="Transparent"
-                                                        SnapsToDevicePixels="False"
                                                         UseLayoutRounding="True">
                                                     <Viewbox>
                                                         <!--  MAGNIFIER / DELETE ICON  Width="18"  -->
@@ -242,7 +240,6 @@
                                         <Setter.Value>
                                             <ControlTemplate TargetType="ToggleButton">
                                                 <Grid Background="Transparent"
-                                                      SnapsToDevicePixels="False"
                                                       UseLayoutRounding="True">
                                                     <Viewbox>
                                                         <Path x:Name="PathToggle"
@@ -469,7 +466,7 @@
                                         </Grid>
                                     </ControlTemplate>
                                 </ScrollViewer.Template>
-                                <ItemsPresenter SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                <ItemsPresenter />
                             </ScrollViewer>
                             <!-- STATUS BAR & RESULT FILTER -->
                             <Border x:Name="BorderStatusBar"
@@ -598,7 +595,7 @@
                                 <ContentPresenter RecognizesAccessKey="True"
                                                   VerticalAlignment="Center"
                                                   MinWidth="20"
-                                                  SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                                  />
                             </DockPanel>
                         </Border>
                         <Thumb x:Name="PART_LeftHeaderGripper"
@@ -631,7 +628,6 @@
         <Border x:Name="BorderButton"
                 Background="Transparent"
                 BorderThickness="0"
-                SnapsToDevicePixels="False"
                 UseLayoutRounding="True">
             <icon:PackIcon x:Name="Icon"
                            Kind="KeyboardArrowDown"
@@ -783,7 +779,6 @@
                                                         UseLayoutRounding="True">
                                                     <Grid x:Name="ContentGrid"
                                                           Background="Transparent"
-                                                          SnapsToDevicePixels="False"
                                                           UseLayoutRounding="True">
                                                         <Grid.ColumnDefinitions>
                                                             <ColumnDefinition Width="Auto" />


### PR DESCRIPTION
This pull request updates the project dependencies and refines UI control templates for better maintainability and compatibility. The most important changes include updating the `DPUnity.Wpf.UI` package version, adding a new dependency on `HandyControls`, and cleaning up unnecessary or redundant XAML properties related to device pixel snapping.

**Dependency updates:**

* Updated the `DPUnity.Wpf.UI` package reference to version `1.0.8.4` and added a new dependency on `HandyControls` version `3.6.0` in `DPUnity.Wpf.DpDataGrid.csproj`.

**UI template and property clean-up:**

* Removed `SnapsToDevicePixels` properties from several XAML control templates (`DataGridCell`, `Button`, `ToggleButton`, `ScrollViewer`, `ContentPresenter`, and custom icon buttons) in `Generic.xaml` to simplify the templates and prevent unnecessary property bindings. [[1]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L67-R69) [[2]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L171) [[3]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L245) [[4]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L472-R469) [[5]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L601-R598) [[6]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L634) [[7]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L786)This pull request updates project dependencies and refines UI control templates for improved consistency and compatibility. The most important changes are grouped below by theme.

**Dependency Updates:**

* Upgraded the `DPUnity.Wpf.UI` package reference from version `1.0.8.2-preview-7` to `1.0.8.4`, and added a new dependency on `HandyControls` version `3.6.0` in `DPUnity.Wpf.DpDataGrid.csproj`.

**UI Template and Layout Adjustments:**

* Removed or simplified the use of the `SnapsToDevicePixels` property in several control templates within `Generic.xaml`, which may help with visual consistency and reduce unnecessary property bindings. [[1]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L67-R69) [[2]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L171) [[3]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L245) [[4]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L472-R469) [[5]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L601-R598) [[6]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L634) [[7]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L786)

**General Project Maintenance:**

* Fixed file encoding in the project file `DPUnity.Wpf.DpDataGrid.csproj` to ensure compatibility with tooling.
This pull request updates the project dependencies and refines UI control templates for better maintainability and compatibility. The most important changes include updating the `DPUnity.Wpf.UI` package version, adding a new dependency on `HandyControls`, and cleaning up unnecessary or redundant XAML properties related to device pixel snapping.

**Dependency updates:**

* Updated the `DPUnity.Wpf.UI` package reference to version `1.0.8.4` and added a new dependency on `HandyControls` version `3.6.0` in `DPUnity.Wpf.DpDataGrid.csproj`.

**UI template and property clean-up:**

* Removed `SnapsToDevicePixels` properties from several XAML control templates (`DataGridCell`, `Button`, `ToggleButton`, `ScrollViewer`, `ContentPresenter`, and custom icon buttons) in `Generic.xaml` to simplify the templates and prevent unnecessary property bindings. [[1]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L67-R69) [[2]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L171) [[3]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L245) [[4]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L472-R469) [[5]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L601-R598) [[6]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L634) [[7]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L786)