### PR TITLE
Update version and refactor FilterDataGrid display

### DIFF
--- a/src/DPUnity.Wpf.DpDataGrid.csproj
+++ b/src/DPUnity.Wpf.DpDataGrid.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<UseWPF>true</UseWPF>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<Version>1.0.13</Version>
+		<Version>1.0.14</Version>
 		<PackageId>DPUnity.Wpf.DpDataGrid</PackageId>
 		<Title>DPUnity WPF DataGrid</Title>
 		<Description>Enhanced DataGrid controls for WPF applications</Description>
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.13" />
+		<PackageReference Include="DPUnity.Wpf.UI" Version="1.0.22" />
 		<PackageReference Include="HandyControls" Version="3.6.0" />
 	</ItemGroup>
 

--- a/src/FilterDataGrid.cs
+++ b/src/FilterDataGrid.cs
@@ -21,7 +21,6 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
-using System.Windows.Media;
 using System.Windows.Threading;
 
 namespace DPUnity.Wpf.DpDataGrid
@@ -125,15 +124,6 @@ namespace DPUnity.Wpf.DpDataGrid
                 typeof(Local),
                 typeof(FilterDataGrid),
                 new PropertyMetadata(Local.English));
-
-        /// <summary>
-        ///     Show elapsed time in status bar
-        /// </summary>
-        public static readonly DependencyProperty ShowElapsedTimeProperty =
-            DependencyProperty.Register("ShowElapsedTime",
-                typeof(bool),
-                typeof(FilterDataGrid),
-                new PropertyMetadata(false));
 
         /// <summary>
         ///     Show status bar
@@ -325,15 +315,6 @@ namespace DPUnity.Wpf.DpDataGrid
         ///     Display items count
         /// </summary>
         public int ItemsSourceCount { get; set; }
-
-        /// <summary>
-        ///     Show elapsed time in status bar
-        /// </summary>
-        public bool ShowElapsedTime
-        {
-            get => (bool)GetValue(ShowElapsedTimeProperty);
-            set => SetValue(ShowElapsedTimeProperty, value);
-        }
 
         /// <summary>
         ///     Show status bar

--- a/src/Themes/Generic.xaml
+++ b/src/Themes/Generic.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:control="clr-namespace:DPUnity.Wpf.DpDataGrid"
                     xmlns:converters="clr-namespace:DPUnity.Wpf.DpDataGrid.Converters"
@@ -525,26 +525,19 @@
                                             </MultiBinding>
                                         </TextBlock.Text>
                                     </TextBlock>
-                                    <!-- ELAPSED TIME -->
-                                    <TextBlock HorizontalAlignment="Right">
-                                        <TextBlock.Text>
-                                            <MultiBinding Converter="{StaticResource StringFormatConverter}"
-                                                          ConverterParameter="Culture">
-                                                <Binding Path="Translate.ElapsedTime"
-                                                         UpdateSourceTrigger="PropertyChanged" />
-                                                <Binding Path="ElapsedTime" />
-                                                <Binding Path="Translate.Culture" />
-                                            </MultiBinding>
-                                        </TextBlock.Text>
+                                    <TextBlock HorizontalAlignment="Right"
+                                               Foreground="{DynamicResource SecondaryTextBrush}"
+                                               Text="{Binding SelectedItems.Count, StringFormat=Đang chọn: {0}}">
                                         <TextBlock.Style>
-                                            <Style TargetType="TextBlock">
+                                            <Style TargetType="TextBlock"
+                                                   BasedOn="{StaticResource DP_TextblockBase}">
                                                 <Setter Property="Visibility"
-                                                        Value="Collapsed" />
+                                                        Value="Visible" />
                                                 <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding ShowElapsedTime}"
-                                                                 Value="True">
+                                                    <DataTrigger Binding="{Binding SelectedItems.Count}"
+                                                                 Value="0">
                                                         <Setter Property="Visibility"
-                                                                Value="Visible" />
+                                                                Value="Collapsed" />
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>


### PR DESCRIPTION
This pull request updates the `DPUnity.Wpf.DpDataGrid` package and refines the status bar display in the DataGrid component. The main changes are the removal of the "elapsed time" feature from the status bar and the introduction of a new display showing the number of selected items. Additionally, there are dependency and version updates.

**Status Bar and UI Changes:**

* Removed the "ShowElapsedTime" dependency property and all related code and UI elements from the `FilterDataGrid` control and its XAML template, simplifying the status bar. [[1]](diffhunk://#diff-0123eccd39b3f151199313b330abc3fd3b92930555a0ef2ce15150f5beb5c732L129-L137) [[2]](diffhunk://#diff-0123eccd39b3f151199313b330abc3fd3b92930555a0ef2ce15150f5beb5c732L329-L337) [[3]](diffhunk://#diff-bbf636b1b305c2ef75af50df20d12fed73d97fa35f4ecd68ef56e4a35ee3a9c0L528-R540)
* Added a new status bar element that displays the count of selected items, with improved styling and visibility logic.

**Dependency and Version Updates:**

* Updated the package version in `DPUnity.Wpf.DpDataGrid.csproj` from `1.0.13` to `1.0.14`.
* Updated the referenced version of `DPUnity.Wpf.UI` from `1.0.13` to `1.0.22` in the project file.

**Code Cleanup:**

* Removed an unused `using System.Windows.Media;` directive from `FilterDataGrid.cs`.
* Fixed BOM encoding in `Generic.xaml` to ensure proper file formatting.- Bump project version to 1.0.14 and update DPUnity.Wpf.UI package to 1.0.22.
- Remove elapsed time properties from FilterDataGrid.
- Update Generic.xaml to display selected items count instead of elapsed time.